### PR TITLE
build(parent): add pluginManagement baseline (Surefire, Failsafe, JaCoCo, Checkstyle, SpotBugs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,4 +29,45 @@
         <module>gateway</module>
     </modules>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!-- Exécute les tests unitaires (phase 'test') -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.2.5</version>
+                    <!-- Pas de config spéciale pour l’instant -->
+                </plugin>
+                <!-- Mesure la couverture des tests (rapport HTML/XML) -->
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.11</version>
+                    <!-- Pas d'executions pour l'instant : on pose juste la version -->
+                </plugin>
+                <!-- Vérifie les conventions de code (formatage, noms, imports, etc.) -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>3.3.1</version>
+                    <!-- Pas d'executions pour l'instant -->
+                </plugin>
+                <!-- Analyse statique pour détecter des bugs potentiels -->
+                <plugin>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>4.8.6.5</version>
+                    <!-- Pas d'executions pour l'instant -->
+                </plugin>
+                <!-- Lance les tests d'intégration (phase 'integration-test' / 'verify') -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>3.2.5</version>
+                    <!-- Pas d'executions pour l'instant -->
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>


### PR DESCRIPTION
- Ajout des plugins en pluginManagement au parent :
  - maven-surefire-plugin (tests unitaires)
  - maven-failsafe-plugin (tests d’intégration)
  - jacoco-maven-plugin (couverture)
  - maven-checkstyle-plugin (style)
  - spotbugs-maven-plugin (analyse statique)
- Pas d’exécutions activées → zéro impact runtime pour l’instant
- mvn clean verify OK
